### PR TITLE
chore: add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Jeremie Drouet <jeremie.drouet@gmail.com>"]
 license = "MIT"
 version = "0.1.4"
 edition = "2021"
+repository = "https://github.com/jdrouet/git-metrics"
 
 [features]
 default = ["impl-command", "impl-git2"]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.