### PR TITLE
Replace hand-written verbosity parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d92b1fab272fe943881b77cc6e920d6543e5b1bfadbd5ed81c7c5a755742394"
+dependencies = [
+ "clap",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +283,7 @@ dependencies = [
  "another-html-builder",
  "auth-git2",
  "clap",
+ "clap-verbosity-flag",
  "git2",
  "human-number",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ impl-git2 = ["dep:git2", "dep:auth-git2"]
 another-html-builder = "0.2"
 auth-git2 = { version = "0.5", optional = true, features = ["log"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+clap-verbosity-flag = { version = "3", features = ["tracing"] }
 git2 = { version = "0.20", optional = true }
 human-number = { version = "0.1" }
 indexmap = { version = "2.11", features = ["serde"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,8 +90,8 @@ struct Args {
     backend: Backend,
 
     /// Enables verbosity
-    #[clap(short, long, action = clap::ArgAction::Count, env = "VERBOSITY")]
-    verbose: u8,
+    #[command(flatten)]
+    verbose: clap_verbosity_flag::Verbosity<clap_verbosity_flag::InfoLevel>,
 
     #[command(subcommand)]
     command: cmd::Command,
@@ -123,14 +123,7 @@ impl Args {
     }
 
     fn log_level(&self) -> Option<tracing::Level> {
-        match self.verbose {
-            0 => None,
-            1 => Some(tracing::Level::ERROR),
-            2 => Some(tracing::Level::WARN),
-            3 => Some(tracing::Level::INFO),
-            4 => Some(tracing::Level::DEBUG),
-            _ => Some(tracing::Level::TRACE),
-        }
+        self.verbose.tracing_level()
     }
 
     fn execute<Out: std::io::Write, Err: std::io::Write>(


### PR DESCRIPTION
This patch replaces the hand-written verbosity parsing with the clap-verbosity-flag crate, and sets the default verbosity to INFO level.

clap-verbosity-flag automatically adds a --quiet option to decrease verbosity.

---

A quick `cargo run -- --help` showed that it works as expected.