### PR TITLE
Fix: Ignore broken pipe error

### DIFF
--- a/src/cmd/log/format.rs
+++ b/src/cmd/log/format.rs
@@ -75,7 +75,13 @@ impl TextFormatter {
             self.format_commit(&commit, &mut stdout)?;
             for metric in metrics.into_metric_iter() {
                 let formatter = config.formatter(metric.header.name.as_str());
-                self.format_metric(&metric, &formatter, &mut stdout)?;
+                if let Err(error) = self.format_metric(&metric, &formatter, &mut stdout) {
+                    if error.kind() == std::io::ErrorKind::BrokenPipe {
+                        return Ok(());
+                    }
+
+                    return Err(error);
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Fixes

```
git metrics log | less
```

printing an error when `less` does not consume the whole log.