### PR TITLE
fix: ignore broken pipe error

### DIFF
--- a/src/cmd/log/format.rs
+++ b/src/cmd/log/format.rs
@@ -75,13 +75,7 @@ impl TextFormatter {
             self.format_commit(&commit, &mut stdout)?;
             for metric in metrics.into_metric_iter() {
                 let formatter = config.formatter(metric.header.name.as_str());
-                if let Err(error) = self.format_metric(&metric, &formatter, &mut stdout) {
-                    if error.kind() == std::io::ErrorKind::BrokenPipe {
-                        return Ok(());
-                    }
-
-                    return Err(error);
-                }
+                self.format_metric(&metric, &formatter, &mut stdout)?;
             }
         }
         Ok(())

--- a/src/cmd/log/format.rs
+++ b/src/cmd/log/format.rs
@@ -75,7 +75,13 @@ impl TextFormatter {
             self.format_commit(&commit, &mut stdout)?;
             for metric in metrics.into_metric_iter() {
                 let formatter = config.formatter(metric.header.name.as_str());
-                self.format_metric(&metric, &formatter, &mut stdout)?;
+                if let Err(error) = self.format_metric(&metric, &formatter, &mut stdout) {
+                    if error.kind() == std::io::ErrorKind::BrokenPipe {
+                        return Ok(());
+                    }
+
+                    return Err(error);
+                }
             }
         }
         Ok(())

--- a/src/cmd/log/mod.rs
+++ b/src/cmd/log/mod.rs
@@ -34,11 +34,15 @@ impl super::Executor for CommandLog {
             remote: self.remote.as_str(),
             target: self.target.as_str(),
         })?;
-        format::TextFormatter {
+        match (format::TextFormatter {
             filter_empty: self.filter_empty,
+        })
+        .format(result, &config, stdout)
+        {
+            Ok(()) => Ok(ExitCode::Success),
+            Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => Ok(ExitCode::Success),
+            Err(error) => Err(error.into()),
         }
-        .format(result, &config, stdout)?;
-        Ok(ExitCode::Success)
     }
 }
 


### PR DESCRIPTION
## Summary
- Ignore `BrokenPipe` errors from `git metrics log` so piping into `less` (and quitting before EOF) does not surface an I/O error.
- Handles the error at the outermost call site so every write in the format pipeline (commit lines and metric lines) is covered, not just one inner helper.

Builds on top of #242 (credit @matthiasbeyer for the original fix).

## Test plan
- [ ] `git metrics log | less` and quit before reaching the end — no error printed
- [ ] `git metrics log` with no pipe still works normally
- [ ] `cargo test` passes