### PR TITLE
feat(cli): allow overriding config path via --config

### DIFF
--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -24,6 +24,7 @@ impl super::Executor for CommandAdd {
         self,
         backend: B,
         _stdout: Out,
+        _config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
         let metric = crate::entity::metric::Metric {
             header: crate::entity::metric::MetricHeader {
@@ -60,7 +61,7 @@ mod tests {
 
         let code = crate::Args::parse_from(["_", "add", "my-metric", "--tag", "foo: bar", "12.34"])
             .command
-            .execute(repo, false, &mut stdout, &mut stderr);
+            .execute(repo, false, &mut stdout, &mut stderr, None);
 
         assert!(code.is_success());
         assert!(stdout.is_empty());
@@ -85,7 +86,7 @@ mod tests {
             "12.34",
         ])
         .command
-        .execute(repo.clone(), false, &mut stdout, &mut stderr);
+        .execute(repo.clone(), false, &mut stdout, &mut stderr, None);
 
         assert!(code.is_success());
         assert!(stdout.is_empty());
@@ -116,7 +117,7 @@ yolo = "pouwet"
 
         let code = crate::Args::parse_from(["_", "add", "--target", "other", "my-metric", "12.34"])
             .command
-            .execute(repo.clone(), false, &mut stdout, &mut stderr);
+            .execute(repo.clone(), false, &mut stdout, &mut stderr, None);
 
         assert!(code.is_success());
         assert!(stdout.is_empty());

--- a/src/cmd/check/mod.rs
+++ b/src/cmd/check/mod.rs
@@ -33,8 +33,9 @@ impl super::Executor for CommandCheck {
         self,
         backend: B,
         stdout: Out,
+        config_override: Option<std::path::PathBuf>,
     ) -> Result<crate::ExitCode, crate::service::Error> {
-        let svc = Service::new(backend);
+        let svc = Service::new(backend).with_config_override(config_override);
         let config = svc.open_config()?;
         let checklist = svc.check(
             &config,

--- a/src/cmd/diff/mod.rs
+++ b/src/cmd/diff/mod.rs
@@ -32,8 +32,9 @@ impl super::Executor for CommandDiff {
         self,
         backend: B,
         stdout: Out,
+        config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
-        let svc = Service::new(backend);
+        let svc = Service::new(backend).with_config_override(config_override);
         let config = svc.open_config()?;
         let opts = crate::service::diff::Options {
             remote: self.remote.as_str(),

--- a/src/cmd/export/mod.rs
+++ b/src/cmd/export/mod.rs
@@ -55,8 +55,9 @@ impl super::Executor for CommandExport {
         self,
         backend: B,
         stdout: Out,
+        config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
-        let svc = Service::new(backend);
+        let svc = Service::new(backend).with_config_override(config_override);
         let config = svc.open_config()?;
 
         let checks = svc.check(

--- a/src/cmd/import/mod.rs
+++ b/src/cmd/import/mod.rs
@@ -46,6 +46,7 @@ impl crate::cmd::Executor for CommandImport {
         self,
         backend: B,
         _stdout: Out,
+        _config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
         let metrics = self.importer.import()?;
         if metrics.is_empty() {

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -11,9 +11,14 @@ impl crate::cmd::Executor for CommandInit {
         self,
         backend: B,
         _stdout: Out,
+        config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
-        let root = backend.root_path()?;
-        Config::write_sample(&root)?;
+        if let Some(path) = config_override.as_deref() {
+            Config::write_sample_to(path)?;
+        } else {
+            let root = backend.root_path()?;
+            Config::write_sample(&root)?;
+        }
         Ok(ExitCode::Success)
     }
 }
@@ -30,7 +35,7 @@ mod tests {
     fn should_do_nothing_for_now() {
         let backend = crate::backend::mock::MockBackend::default();
         let stdout = BasicWriter::from(Vec::<u8>::new());
-        let cmd = CommandInit::parse_from(["_"]).execute(backend, stdout);
+        let cmd = CommandInit::parse_from(["_"]).execute(backend, stdout, None);
         assert!(cmd.is_ok());
     }
 }

--- a/src/cmd/log/mod.rs
+++ b/src/cmd/log/mod.rs
@@ -27,8 +27,9 @@ impl super::Executor for CommandLog {
         self,
         backend: B,
         stdout: Out,
+        config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
-        let svc = Service::new(backend);
+        let svc = Service::new(backend).with_config_override(config_override);
         let config = svc.open_config()?;
         let result = svc.log(&crate::service::log::Options {
             remote: self.remote.as_str(),

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 use std::io::Write;
+use std::path::PathBuf;
 
 use prelude::{BasicWriter, ColoredWriter, PrettyWriter};
 
@@ -28,6 +29,7 @@ trait Executor {
         self,
         backend: B,
         stdout: Out,
+        config_override: Option<PathBuf>,
     ) -> Result<ExitCode, crate::service::Error>;
 }
 
@@ -58,20 +60,21 @@ impl Command {
         self,
         repo: Repo,
         stdout: Out,
+        config_override: Option<PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
         match self {
-            Self::Add(inner) => inner.execute(repo, stdout),
-            Self::Check(inner) => inner.execute(repo, stdout),
-            Self::Diff(inner) => inner.execute(repo, stdout),
-            Self::Export(inner) => inner.execute(repo, stdout),
-            Self::Init(inner) => inner.execute(repo, stdout),
+            Self::Add(inner) => inner.execute(repo, stdout, config_override),
+            Self::Check(inner) => inner.execute(repo, stdout, config_override),
+            Self::Diff(inner) => inner.execute(repo, stdout, config_override),
+            Self::Export(inner) => inner.execute(repo, stdout, config_override),
+            Self::Init(inner) => inner.execute(repo, stdout, config_override),
             #[cfg(feature = "importer")]
-            Self::Import(inner) => inner.execute(repo, stdout),
-            Self::Log(inner) => inner.execute(repo, stdout),
-            Self::Pull(inner) => inner.execute(repo, stdout),
-            Self::Push(inner) => inner.execute(repo, stdout),
-            Self::Remove(inner) => inner.execute(repo, stdout),
-            Self::Show(inner) => inner.execute(repo, stdout),
+            Self::Import(inner) => inner.execute(repo, stdout, config_override),
+            Self::Log(inner) => inner.execute(repo, stdout, config_override),
+            Self::Pull(inner) => inner.execute(repo, stdout, config_override),
+            Self::Push(inner) => inner.execute(repo, stdout, config_override),
+            Self::Remove(inner) => inner.execute(repo, stdout, config_override),
+            Self::Show(inner) => inner.execute(repo, stdout, config_override),
         }
     }
 
@@ -81,11 +84,12 @@ impl Command {
         color_enabled: bool,
         stdout: Out,
         stderr: Err,
+        config_override: Option<PathBuf>,
     ) -> ExitCode {
         let result = if color_enabled {
-            self.execute_with(repo, ColoredWriter::from(stdout))
+            self.execute_with(repo, ColoredWriter::from(stdout), config_override)
         } else {
-            self.execute_with(repo, BasicWriter::from(stdout))
+            self.execute_with(repo, BasicWriter::from(stdout), config_override)
         };
 
         match result {

--- a/src/cmd/pull.rs
+++ b/src/cmd/pull.rs
@@ -17,6 +17,7 @@ impl super::Executor for CommandPull {
         self,
         backend: B,
         _stdout: Out,
+        _config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
         Service::new(backend).pull(&crate::service::pull::Options {
             remote: self.remote.as_str(),

--- a/src/cmd/push.rs
+++ b/src/cmd/push.rs
@@ -17,6 +17,7 @@ impl super::Executor for CommandPush {
         self,
         backend: B,
         _stdout: Out,
+        _config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
         Service::new(backend).push(&crate::service::push::Options {
             remote: self.remote.as_str(),

--- a/src/cmd/remove.rs
+++ b/src/cmd/remove.rs
@@ -22,6 +22,7 @@ impl super::Executor for CommandRemove {
         self,
         backend: B,
         _stdout: Out,
+        _config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
         Service::new(backend).remove(
             self.index,
@@ -49,7 +50,7 @@ mod tests {
 
         let code = crate::Args::parse_from(["_", "remove", "0"])
             .command
-            .execute(backend, false, &mut stdout, &mut stderr);
+            .execute(backend, false, &mut stdout, &mut stderr, None);
 
         assert!(code.is_success());
         assert!(stdout.is_empty());

--- a/src/cmd/show.rs
+++ b/src/cmd/show.rs
@@ -21,8 +21,9 @@ impl super::Executor for CommandShow {
         self,
         backend: B,
         mut stdout: Out,
+        config_override: Option<std::path::PathBuf>,
     ) -> Result<ExitCode, crate::service::Error> {
-        let svc = Service::new(backend);
+        let svc = Service::new(backend).with_config_override(config_override);
         let config = svc.open_config()?;
         let metrics = svc.show(&crate::service::show::Options {
             remote: self.remote.as_str(),
@@ -56,6 +57,7 @@ mod tests {
             false,
             &mut stdout,
             &mut stderr,
+            None,
         );
 
         assert!(code.is_success());
@@ -96,7 +98,7 @@ value = 1.0
 
         let code = crate::Args::parse_from(["_", "show", "--target", sha])
             .command
-            .execute(repo, false, &mut stdout, &mut stderr);
+            .execute(repo, false, &mut stdout, &mut stderr, None);
 
         assert!(code.is_success(), "{:?}", String::from_utf8_lossy(&stderr));
         assert!(!stdout.is_empty());

--- a/src/entity/config.rs
+++ b/src/entity/config.rs
@@ -243,6 +243,10 @@ impl Config {
         let config_path = Self::config_path(root);
         std::fs::write(&config_path, sample())
     }
+
+    pub(crate) fn write_sample_to(path: &Path) -> std::io::Result<()> {
+        std::fs::write(path, sample())
+    }
 }
 
 impl FromStr for Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,13 @@ struct Args {
     #[clap(long, env = "CI")]
     ci: bool,
 
+    /// Path to an alternative configuration file
+    ///
+    /// If not specified, git-metrics looks for `.git-metrics.toml` at the root of the
+    /// repository.
+    #[clap(global = true, long, env = "GIT_METRICS_CONFIG")]
+    config: Option<PathBuf>,
+
     /// Disable the colors in the output text
     ///
     /// The color will only be enabled if we detect that your environment is compatible.
@@ -138,6 +145,7 @@ impl Args {
                 color,
                 stdout,
                 stderr,
+                self.config,
             ),
             #[cfg(feature = "impl-git2")]
             Backend::Git2 => self.command.execute(
@@ -147,6 +155,7 @@ impl Args {
                 color,
                 stdout,
                 stderr,
+                self.config,
             ),
         }
     }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::backend::{Backend, NoteRef};
 use crate::entity::config::Config;
 use crate::entity::metric::{Metric, MetricChange, MetricStack};
@@ -64,14 +66,26 @@ struct ChangeList {
 
 pub(crate) struct Service<B> {
     backend: B,
+    config_override: Option<PathBuf>,
 }
 
 impl<B: Backend> Service<B> {
     pub(crate) fn new(backend: B) -> Self {
-        Self { backend }
+        Self {
+            backend,
+            config_override: None,
+        }
+    }
+
+    pub(crate) fn with_config_override(mut self, path: Option<PathBuf>) -> Self {
+        self.config_override = path;
+        self
     }
 
     pub(crate) fn open_config(&self) -> Result<Config, Error> {
+        if let Some(path) = self.config_override.as_deref() {
+            return Config::from_path(path).map_err(Error::from);
+        }
         let root = self.backend.root_path()?;
         Config::from_root_path(&root).map_err(Error::from)
     }

--- a/src/tests/config_override.rs
+++ b/src/tests/config_override.rs
@@ -1,0 +1,159 @@
+use crate::tests::GitRepo;
+
+fn setup(backend: &'static str, root: &std::path::Path) -> GitRepo {
+    let server = GitRepo::create(backend, root.join("server"));
+    let client = GitRepo::clone(&server, root.join("client"));
+    client.commit("first commit");
+    client.push();
+    client
+        .metrics_exec(backend, ["pull"])
+        .expect("initial pull");
+    client
+        .metrics_exec(backend, ["add", "binary-size", "100.0"])
+        .expect("add on first commit");
+    client.commit("second commit");
+    client
+        .metrics_exec(backend, ["add", "binary-size", "100.0"])
+        .expect("add on second commit");
+    client
+}
+
+#[test_case::test_case("git2"; "with git2 backend")]
+#[test_case::test_case("command"; "with command backend")]
+fn override_overrides_repo_config(backend: &'static str) {
+    super::init_logs();
+
+    let root = tempfile::tempdir().unwrap();
+
+    let client = setup(backend, root.path());
+
+    let repo_cfg = client.path.join(".git-metrics.toml");
+    std::fs::write(
+        &repo_cfg,
+        r#"[metrics.binary-size]
+[[metrics.binary-size.rules]]
+type = "max"
+value = 1000.0
+"#,
+    )
+    .unwrap();
+
+    let alt_cfg = root.path().join("strict.toml");
+    std::fs::write(
+        &alt_cfg,
+        r#"[metrics.binary-size]
+[[metrics.binary-size.rules]]
+type = "max"
+value = 10.0
+"#,
+    )
+    .unwrap();
+
+    client
+        .metrics_exec(backend, ["check", "HEAD"])
+        .expect("repo config allows up to 1000");
+
+    let alt_cfg_str = alt_cfg.to_string_lossy().to_string();
+    client
+        .metrics_exec(backend, ["--config", alt_cfg_str.as_str(), "check", "HEAD"])
+        .expect_err("strict override caps at 10");
+}
+
+#[test_case::test_case("git2"; "with git2 backend")]
+#[test_case::test_case("command"; "with command backend")]
+fn override_applies_when_repo_has_no_config(backend: &'static str) {
+    super::init_logs();
+
+    let root = tempfile::tempdir().unwrap();
+    let client = setup(backend, root.path());
+
+    let alt_cfg = root.path().join("alt.toml");
+    std::fs::write(
+        &alt_cfg,
+        r#"[metrics.binary-size]
+[[metrics.binary-size.rules]]
+type = "max"
+value = 10.0
+"#,
+    )
+    .unwrap();
+
+    client
+        .metrics_exec(backend, ["check", "HEAD"])
+        .expect("no repo config, no rules to break");
+
+    let alt_cfg_str = alt_cfg.to_string_lossy().to_string();
+    client
+        .metrics_exec(backend, ["--config", alt_cfg_str.as_str(), "check", "HEAD"])
+        .expect_err("override should make the rule fail");
+}
+
+#[test_case::test_case("git2"; "with git2 backend")]
+#[test_case::test_case("command"; "with command backend")]
+fn missing_override_path_errors_clearly(backend: &'static str) {
+    super::init_logs();
+
+    let root = tempfile::tempdir().unwrap();
+    let client = setup(backend, root.path());
+
+    let missing = root.path().join("does-not-exist.toml");
+    let missing_str = missing.to_string_lossy().to_string();
+
+    let err = client
+        .metrics_exec(backend, ["--config", missing_str.as_str(), "check", "HEAD"])
+        .expect_err("missing override path should fail");
+    assert!(
+        err.to_lowercase().contains("no such file")
+            || err.to_lowercase().contains("not found")
+            || err.to_lowercase().contains("cannot find"),
+        "expected a missing-file error, got: {err}"
+    );
+}
+
+#[test_case::test_case("git2"; "with git2 backend")]
+#[test_case::test_case("command"; "with command backend")]
+fn override_ignored_by_commands_that_dont_read_config(backend: &'static str) {
+    super::init_logs();
+
+    let root = tempfile::tempdir().unwrap();
+    let server = GitRepo::create(backend, root.path().join("server"));
+    let client = GitRepo::clone(&server, root.path().join("client"));
+    client.commit("first commit");
+    client.push();
+    client.metrics_exec(backend, ["pull"]).unwrap();
+
+    let missing = root.path().join("does-not-exist.toml");
+    let missing_str = missing.to_string_lossy().to_string();
+
+    client
+        .metrics_exec(
+            backend,
+            ["--config", missing_str.as_str(), "add", "anything", "1.0"],
+        )
+        .expect("add should not read the config file");
+}
+
+#[test_case::test_case("git2"; "with git2 backend")]
+#[test_case::test_case("command"; "with command backend")]
+fn init_writes_to_override_path(backend: &'static str) {
+    super::init_logs();
+
+    let root = tempfile::tempdir().unwrap();
+    let server = GitRepo::create(backend, root.path().join("server"));
+    let client = GitRepo::clone(&server, root.path().join("client"));
+    client.commit("first commit");
+    client.push();
+
+    let target = root.path().join("custom.toml");
+    let target_str = target.to_string_lossy().to_string();
+
+    client
+        .metrics_exec(backend, ["--config", target_str.as_str(), "init"])
+        .unwrap();
+
+    assert!(target.exists(), "init should have created {target_str}");
+    assert!(
+        !client.path.join(".git-metrics.toml").exists(),
+        "init with --config should not touch the default location"
+    );
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 mod check_budget;
+mod config_override;
 mod conflict_different;
 mod display_diff;
 mod simple_use_case;


### PR DESCRIPTION
## Summary

- Adds a global `--config <path>` flag (also `GIT_METRICS_CONFIG` env var) so users can point git-metrics at an alternative TOML config instead of the repo-root `.git-metrics.toml`.
- The override lives on `Service` via a new `with_config_override` builder; `open_config` consults it lazily, so commands that don't read config don't pay the I/O cost.
- `init` honors the override and writes the sample config to the requested path.

Supersedes #191 — same goal, different shape: rather than threading a pre-loaded `Option<Config>` through every executor and repeating the `if let Some else open_config` pattern in five commands, the override is a single `Option<PathBuf>` resolved lazily inside `Service`. The flag is `global = true` so both \`git-metrics --config foo.toml check\` and \`git-metrics check --config foo.toml\` work.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --all-targets\`
- [x] \`cargo test\` (69/69 passing, including 10 new cases across both backends)
- [x] Override applies when the repo has no config
- [x] Override beats the repo config when both are present
- [x] Missing override path produces a clear error
- [x] Commands that don't read config (\`add\`, \`pull\`, ...) ignore the override even when the path is missing
- [x] \`init --config <path>\` writes the sample to that path and leaves the default location untouched